### PR TITLE
Updated references to `one(of:)`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ property("Shrunken lists of integers always contain [] or [0]") <- forAll { (l :
 Properties can even depend on other properties:
 
 ```swift
-property("Gen.oneOf multiple generators picks only given generators") <- forAll { (n1 : Int, n2 : Int) in
+property("Gen.one(of:) multiple generators picks only given generators") <- forAll { (n1 : Int, n2 : Int) in
     let g1 = Gen.pure(n1)
     let g2 = Gen.pure(n2)
     // Here we give `forAll` an explicit generator.  Before SwiftCheck was using
     // the types of variables involved in the property to create an implicit
     // Generator behind the scenes.
-    return forAll(Gen.oneOf([g1, g2])) { $0 == n1 || $0 == n2 }
+    return forAll(Gen.one(of: [g1, g2])) { $0 == n1 || $0 == n2 }
 }
 ```
 


### PR DESCRIPTION
What's in this pull request?
============================

Updated references to `one(of:)` that used to be `oneOf`.

Why merge this pull request?
============================

Keep the README up to date.

What's worth discussing about this pull request?
================================================

I'm not sure how this relates to the compatibility versions of Swift.

What downsides are there to merging this pull request?
======================================================

Probably not relevant in context of older versions of Swift.
